### PR TITLE
Decouple builder from operations

### DIFF
--- a/lib/xml_patch/diff_builder.rb
+++ b/lib/xml_patch/diff_builder.rb
@@ -10,7 +10,7 @@ module XmlPatch
       @diff_document = XmlPatch::DiffDocument.new
     end
 
-    def add(op_name, xpath)
+    def register(op_name, xpath)
       op = XmlPatch::Operations.instance(op_name, sel: xpath)
       diff_document << op if op
       diff_document
@@ -30,7 +30,7 @@ module XmlPatch
       end
 
       def on_element(_namespace, name, attrs = {})
-        builder.add name, attrs['sel']
+        builder.register name, attrs['sel']
       end
     end
 

--- a/lib/xml_patch/diff_builder.rb
+++ b/lib/xml_patch/diff_builder.rb
@@ -1,6 +1,6 @@
 require 'oga'
 require 'xml_patch/diff_document'
-require 'xml_patch/operations/remove'
+require 'xml_patch/operations'
 
 module XmlPatch
   class DiffBuilder
@@ -10,8 +10,10 @@ module XmlPatch
       @diff_document = XmlPatch::DiffDocument.new
     end
 
-    def remove(xpath)
-      diff_document << XmlPatch::Operations::Remove.new(sel: xpath)
+    def add(op_name, xpath)
+      op = XmlPatch::Operations.instance(op_name, sel: xpath)
+      diff_document << op if op
+      diff_document
     end
 
     def parse(xml)
@@ -28,9 +30,7 @@ module XmlPatch
       end
 
       def on_element(_namespace, name, attrs = {})
-        case name
-        when 'remove' then builder.remove(attrs['sel'])
-        end
+        builder.add name, attrs['sel']
       end
     end
 

--- a/lib/xml_patch/operations.rb
+++ b/lib/xml_patch/operations.rb
@@ -1,0 +1,17 @@
+module XmlPatch
+  module Operations
+    def self.registry
+      @registry ||= {}
+    end
+
+    def self.instance(op_name, *args)
+      constructor = registry[op_name.to_sym]
+      constructor ? constructor.new(*args) : nil
+    end
+  end
+end
+
+# auto load all available operations
+Dir[File.join(File.dirname(__FILE__), 'operations')].each do |f|
+  require f
+end

--- a/lib/xml_patch/operations/remove.rb
+++ b/lib/xml_patch/operations/remove.rb
@@ -26,5 +26,7 @@ module XmlPatch
         %(<remove sel="#{sel}" />)
       end
     end
+
+    registry[:remove] = Remove
   end
 end

--- a/spec/xml_patch/diff_builder_spec.rb
+++ b/spec/xml_patch/diff_builder_spec.rb
@@ -1,14 +1,13 @@
 require 'spec_helper'
 require 'xml_patch/diff_builder'
 require 'xml_patch/diff_document'
-require 'xml_patch/operations/remove'
 
 RSpec.describe XmlPatch::DiffBuilder do
-  describe 'remove' do
+  describe 'add' do
     it 'appends a remove operation to the diff document' do
       builder = described_class.new
-      builder.remove('/foo/bar')
-      builder.remove('/baz/qux')
+      builder.add('remove', '/foo/bar')
+      builder.add('remove', '/baz/qux')
 
       doc = XmlPatch::DiffDocument.new \
             << XmlPatch::Operations::Remove.new(sel: '/foo/bar') \
@@ -36,19 +35,19 @@ RSpec.describe XmlPatch::DiffBuilder do
       expect(builder.diff_document).to eq(diff)
     end
 
-    it 'calls remove for each <remove> in the input' do
+    it 'adds remove operations for each <remove> in the input' do
       xml = <<-XML
         <remove sel="/foo/bar" />
         <remove sel="/baz/qux" />
       XML
 
       builder = described_class.new
-      allow(builder).to receive(:remove)
+      allow(builder).to receive(:add)
 
       builder.parse(xml)
 
-      expect(builder).to have_received(:remove).with('/foo/bar').ordered
-      expect(builder).to have_received(:remove).with('/baz/qux').ordered
+      expect(builder).to have_received(:add).with('remove', '/foo/bar').ordered
+      expect(builder).to have_received(:add).with('remove', '/baz/qux').ordered
     end
   end
 end

--- a/spec/xml_patch/diff_builder_spec.rb
+++ b/spec/xml_patch/diff_builder_spec.rb
@@ -3,11 +3,11 @@ require 'xml_patch/diff_builder'
 require 'xml_patch/diff_document'
 
 RSpec.describe XmlPatch::DiffBuilder do
-  describe 'add' do
+  describe 'register' do
     it 'appends a remove operation to the diff document' do
       builder = described_class.new
-      builder.add('remove', '/foo/bar')
-      builder.add('remove', '/baz/qux')
+      builder.register('remove', '/foo/bar')
+      builder.register('remove', '/baz/qux')
 
       doc = XmlPatch::DiffDocument.new \
             << XmlPatch::Operations::Remove.new(sel: '/foo/bar') \
@@ -35,19 +35,19 @@ RSpec.describe XmlPatch::DiffBuilder do
       expect(builder.diff_document).to eq(diff)
     end
 
-    it 'adds remove operations for each <remove> in the input' do
+    it 'registers remove operations for each <remove> in the input' do
       xml = <<-XML
         <remove sel="/foo/bar" />
         <remove sel="/baz/qux" />
       XML
 
       builder = described_class.new
-      allow(builder).to receive(:add)
+      allow(builder).to receive(:register)
 
       builder.parse(xml)
 
-      expect(builder).to have_received(:add).with('remove', '/foo/bar').ordered
-      expect(builder).to have_received(:add).with('remove', '/baz/qux').ordered
+      expect(builder).to have_received(:register).with('remove', '/foo/bar').ordered
+      expect(builder).to have_received(:register).with('remove', '/baz/qux').ordered
     end
   end
 end


### PR DESCRIPTION
## What

Remove knowledge of concrete operations from `DiffBuilder`.

## Why

To decouple operations from `DiffBuilder`, so we can implement new operations as we go without having to refactor `DiffBuilder` every time. This way we can just unit-test operations as we add them.

## How

Added a `XmlPatch::Operations.registry` hash, where each operation registers itself.
`DiffBuilder` looks up operations by name ("remove", "add", etc) in the registry, and add them if available.

## Improvements

* New operations might need extra arguments (ex. `Add` probably needs content to be added). We can revise `DiffBuilder#register`'s signature when that happens.
