### PR TITLE
Isolate oga

### DIFF
--- a/lib/xml_patch/applicator.rb
+++ b/lib/xml_patch/applicator.rb
@@ -1,5 +1,5 @@
 require 'xml_patch/diff_builder'
-require 'xml_patch/target_document'
+require 'xml_patch/xml_document'
 
 module XmlPatch
   class Applicator
@@ -11,7 +11,7 @@ module XmlPatch
 
     def to(target_xml)
       diff = XmlPatch::DiffBuilder.new.parse(diff_xml).diff_document
-      target = XmlPatch::TargetDocument.new(target_xml)
+      target = XmlPatch::XmlDocument.new(target_xml)
       diff.apply_to(target)
       target.to_xml
     end

--- a/lib/xml_patch/diff_builder.rb
+++ b/lib/xml_patch/diff_builder.rb
@@ -1,4 +1,3 @@
-require 'oga'
 require 'xml_patch/diff_document'
 require 'xml_patch/operations/remove'
 
@@ -15,25 +14,13 @@ module XmlPatch
     end
 
     def parse(xml)
-      handler = SaxHandler.new(self)
-      Oga.sax_parse_xml(handler, xml)
-      self
-    end
-
-    class SaxHandler
-      attr_reader :builder
-
-      def initialize(builder)
-        @builder = builder
-      end
-
-      def on_element(_namespace, name, attrs = {})
+      diff = XmlDocument.new(xml)
+      diff.parse do |name, attrs|
         case name
-        when 'remove' then builder.remove(attrs['sel'])
+        when 'remove' then remove(attrs['sel'])
         end
       end
+      self
     end
-
-    private_constant :SaxHandler
   end
 end

--- a/lib/xml_patch/xml_document.rb
+++ b/lib/xml_patch/xml_document.rb
@@ -5,20 +5,18 @@ require 'xml_patch/errors/invalid_xpath'
 module XmlPatch
   class XmlDocument
     def initialize(xml)
-      @xml = Oga.parse_xml(xml)
-    rescue LL::ParserError => e
-      raise XmlPatch::Errors::InvalidXml, e.message
+      @xml = xml
     end
 
     def to_xml
-      xml.to_xml
+      xml_dom.to_xml
     end
 
     def remove_at!(xpath)
       nodes = []
 
       begin
-        nodes = xml.xpath(xpath)
+        nodes = xml_dom.xpath(xpath)
       rescue LL::ParserError => e
         raise XmlPatch::Errors::InvalidXpath, e.message
       end
@@ -28,9 +26,21 @@ module XmlPatch
       self
     end
 
+    def parse(&blk)
+      handler = SaxHandler.new(&blk)
+      Oga.sax_parse_xml(handler, xml)
+      nil
+    end
+
     private
 
     attr_reader :xml
+
+    def xml_dom
+      @xml_dom ||= Oga.parse_xml(xml)
+    rescue LL::ParserError => e
+      raise XmlPatch::Errors::InvalidXml, e.message
+    end
 
     def remove_node(node)
       if node.respond_to?(:remove)
@@ -39,5 +49,19 @@ module XmlPatch
         node.element.unset(node.name)
       end
     end
+
+    class SaxHandler
+      attr_reader :block
+
+      def initialize(&block)
+        @block = block
+      end
+
+      def on_element(_namespace, name, attrs = {})
+        block.call(name, attrs)
+      end
+    end
+
+    private_constant :SaxHandler
   end
 end

--- a/lib/xml_patch/xml_document.rb
+++ b/lib/xml_patch/xml_document.rb
@@ -3,7 +3,7 @@ require 'xml_patch/errors/invalid_xml'
 require 'xml_patch/errors/invalid_xpath'
 
 module XmlPatch
-  class TargetDocument
+  class XmlDocument
     def initialize(xml)
       @xml = Oga.parse_xml(xml)
     rescue LL::ParserError => e

--- a/spec/xml_patch/diff_document_spec.rb
+++ b/spec/xml_patch/diff_document_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 require 'xml_patch/diff_document'
-require 'xml_patch/target_document'
+require 'xml_patch/xml_document'
 
 RSpec.describe XmlPatch::DiffDocument do
   it 'is enumerable' do
@@ -42,7 +42,7 @@ RSpec.describe XmlPatch::DiffDocument do
 
   describe 'apply_to' do
     it 'applies each of the operations in order' do
-      doc = XmlPatch::TargetDocument.new('')
+      doc = XmlPatch::XmlDocument.new('')
 
       op1 = double('op1')
       allow(op1).to receive(:apply_to)
@@ -59,7 +59,7 @@ RSpec.describe XmlPatch::DiffDocument do
     end
 
     it 'returns the input document' do
-      doc = XmlPatch::TargetDocument.new('')
+      doc = XmlPatch::XmlDocument.new('')
       diff = described_class.new
       expect(diff.apply_to(doc)).to be(doc)
     end

--- a/spec/xml_patch/operations/remove_spec.rb
+++ b/spec/xml_patch/operations/remove_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 require 'xml_patch/operations/remove'
-require 'xml_patch/target_document'
+require 'xml_patch/xml_document'
 
 RSpec.describe XmlPatch::Operations::Remove do
   describe 'sel' do
@@ -26,7 +26,7 @@ RSpec.describe XmlPatch::Operations::Remove do
   describe 'apply_to' do
     it 'calls remove_at! on the document using sel' do
       op = described_class.new(sel: '/foo/bar')
-      doc = XmlPatch::TargetDocument.new('')
+      doc = XmlPatch::XmlDocument.new('')
       allow(doc).to receive(:remove_at!)
       op.apply_to(doc)
       expect(doc).to have_received(:remove_at!).with('/foo/bar')
@@ -34,7 +34,7 @@ RSpec.describe XmlPatch::Operations::Remove do
 
     it 'returns the input document' do
       op = described_class.new(sel: '/foo/bar')
-      doc = XmlPatch::TargetDocument.new('')
+      doc = XmlPatch::XmlDocument.new('')
       expect(op.apply_to(doc)).to eq(doc)
     end
   end

--- a/spec/xml_patch/xml_document_spec.rb
+++ b/spec/xml_patch/xml_document_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
-require 'xml_patch/target_document'
+require 'xml_patch/xml_document'
 require 'xml_patch/errors/invalid_xml'
 require 'xml_patch/errors/invalid_xpath'
 
-RSpec.describe XmlPatch::TargetDocument do
+RSpec.describe XmlPatch::XmlDocument do
   describe 'new' do
     it 'raises an error if not given valid xml' do
       expect {


### PR DESCRIPTION
The idea of XmlDocument was that it should encapsulate all xml access
methods (so that we could change the xml gem used or provide
adapters). However, DiffBuilder was also using oga, "leaking" the
encapsulation of oga.

To improve that I've refactored XmlDocument so that it provides a sax
parsing interface, which is now used by DiffBuilder, and DiffBuilder
no longer knows about the xml parsing library being used.

Going forwards all xml handling should be performed by the XmlDocument
class.