### PR TITLE
Made sure all internal methods receive XmlDocuments (not strings)

### DIFF
--- a/lib/xml_patch.rb
+++ b/lib/xml_patch.rb
@@ -1,10 +1,12 @@
 require 'xml_patch/version'
 require 'xml_patch/applicator'
+require 'xml_patch/xml_document'
 
 module XmlPatch
   class << self
     def apply(xml)
-      XmlPatch::Applicator.new(xml)
+      patch = XmlPatch::XmlDocument.new(xml)
+      XmlPatch::Applicator.new(patch)
     end
   end
 end

--- a/lib/xml_patch/applicator.rb
+++ b/lib/xml_patch/applicator.rb
@@ -3,17 +3,22 @@ require 'xml_patch/xml_document'
 
 module XmlPatch
   class Applicator
-    attr_reader :diff_xml
-
-    def initialize(diff_xml)
-      @diff_xml = diff_xml.dup.freeze
+    def initialize(patch)
+      @patch = patch
     end
 
     def to(target_xml)
-      diff = XmlPatch::DiffBuilder.new.parse(diff_xml).diff_document
       target = XmlPatch::XmlDocument.new(target_xml)
-      diff.apply_to(target)
+      diff_document.apply_to(target)
       target.to_xml
+    end
+
+    private
+
+    attr_reader :patch
+
+    def diff_document
+      XmlPatch::DiffBuilder.new.parse(patch).diff_document
     end
   end
 end

--- a/lib/xml_patch/diff_builder.rb
+++ b/lib/xml_patch/diff_builder.rb
@@ -13,9 +13,8 @@ module XmlPatch
       diff_document << XmlPatch::Operations::Remove.new(sel: xpath)
     end
 
-    def parse(xml)
-      diff = XmlDocument.new(xml)
-      diff.parse do |name, attrs|
+    def parse(patch)
+      patch.parse do |name, attrs|
         case name
         when 'remove' then remove(attrs['sel'])
         end

--- a/spec/xml_patch/applicator_spec.rb
+++ b/spec/xml_patch/applicator_spec.rb
@@ -1,32 +1,13 @@
 require 'spec_helper'
 require 'xml_patch/applicator'
+require 'xml_patch/xml_document'
 
 RSpec.describe XmlPatch::Applicator do
-  describe 'diff_xml' do
-    it 'is the string passed to the constructor' do
-      applicator = described_class.new('<remove sel="/foo/bar" />')
-      expect(applicator.diff_xml).to eq('<remove sel="/foo/bar" />')
-    end
-
-    it 'cannot be mutated' do
-      applicator = described_class.new('<remove sel="/foo/bar" />')
-      expect {
-        applicator.diff_xml.gsub!(/.*/, '')
-      }.to raise_error(RuntimeError).with_message("can't modify frozen String")
-    end
-
-    it 'is not the same object that was passed to the constructor' do
-      str = '<remove sel="/foo/bar" />'
-      applicator = described_class.new(str)
-      expect(applicator.diff_xml).not_to be(str)
-    end
-  end
-
   describe 'to' do
     it 'applies the diff passed to the constructor against the param of this method' do
       target_xml = '<foo><bar /></foo>'
-      diff_xml = '<remove sel="/foo/bar" />'
-      expect(described_class.new(diff_xml).to(target_xml)).to eq('<foo />')
+      patch = XmlPatch::XmlDocument.new('<remove sel="/foo/bar" />')
+      expect(described_class.new(patch).to(target_xml)).to eq('<foo />')
     end
   end
 end

--- a/spec/xml_patch/diff_builder_spec.rb
+++ b/spec/xml_patch/diff_builder_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'xml_patch/diff_builder'
 require 'xml_patch/diff_document'
+require 'xml_patch/xml_document'
 require 'xml_patch/operations/remove'
 
 RSpec.describe XmlPatch::DiffBuilder do
@@ -18,11 +19,12 @@ RSpec.describe XmlPatch::DiffBuilder do
   end
 
   describe 'parse' do
-    it 'does nothing when given an empty string' do
+    it 'does nothing when given an empty xml document' do
       diff = XmlPatch::DiffDocument.new
 
+      patch = XmlPatch::XmlDocument.new('')
       builder = described_class.new
-      builder.parse('')
+      builder.parse(patch)
 
       expect(builder.diff_document).to eq(diff)
     end
@@ -30,14 +32,15 @@ RSpec.describe XmlPatch::DiffBuilder do
     it 'ignores any unrecognised xml tags' do
       diff = XmlPatch::DiffDocument.new
 
+      patch = XmlPatch::XmlDocument.new('<foo />')
       builder = described_class.new
-      builder.parse('<foo />')
+      builder.parse(patch)
 
       expect(builder.diff_document).to eq(diff)
     end
 
     it 'calls remove for each <remove> in the input' do
-      xml = <<-XML
+      patch = XmlPatch::XmlDocument.new <<-XML
         <remove sel="/foo/bar" />
         <remove sel="/baz/qux" />
       XML
@@ -45,7 +48,7 @@ RSpec.describe XmlPatch::DiffBuilder do
       builder = described_class.new
       allow(builder).to receive(:remove)
 
-      builder.parse(xml)
+      builder.parse(patch)
 
       expect(builder).to have_received(:remove).with('/foo/bar').ordered
       expect(builder).to have_received(:remove).with('/baz/qux').ordered


### PR DESCRIPTION
Previously, `Applicator.new` and `DiffBuilder.parse` would receive a
string which they would immediately parse into an
XmlDocument. However, this tightly couples them to how we parse
xml.

To reduce this coupling I've made both receive an XmlDocument object,
in the expectation that the caller should do the parsing for them.