### PR TITLE
Expect patch xml to have a <diff> root node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Expect patch xml to have a <diff> root node
 
 ## [0.1.0] - 2017-11-01
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To apply an xml patch to an xml string:
 ``` ruby
 require 'xml_patch'
 
-patch = '<remove sel="/foo" />'
+patch = '<diff><remove sel="/foo" /></diff>'
 xml = '<foo /><bar />'
 
 XmlPatch.apply(patch).to(xml)

--- a/lib/xml_patch/diff_document.rb
+++ b/lib/xml_patch/diff_document.rb
@@ -27,7 +27,11 @@ module XmlPatch
     end
 
     def to_xml
-      operations.inject('') { |str, op| str + op.to_xml + "\n" }.chomp
+      if operations.empty?
+        '<diff />'
+      else
+        '<diff>' + operations.map(&:to_xml).join("\n") + '</diff>'
+      end
     end
 
     private

--- a/spec/xml_patch/applicator_spec.rb
+++ b/spec/xml_patch/applicator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe XmlPatch::Applicator do
   describe 'to' do
     it 'applies the diff passed to the constructor against the param of this method' do
       target_xml = '<foo><bar /></foo>'
-      patch = XmlPatch::XmlDocument.new('<remove sel="/foo/bar" />')
+      patch = XmlPatch::XmlDocument.new('<diff><remove sel="/foo/bar" /></diff>')
       expect(described_class.new(patch).to(target_xml)).to eq('<foo />')
     end
   end

--- a/spec/xml_patch/diff_document_spec.rb
+++ b/spec/xml_patch/diff_document_spec.rb
@@ -92,18 +92,18 @@ RSpec.describe XmlPatch::DiffDocument do
   end
 
   describe 'to_xml' do
-    it 'renders each of the operations to xml in order' do
+    it 'renders a patch including each of the operations in order' do
       op1 = double('op1', to_xml: '<op1 />')
       op2 = double('op1', to_xml: '<op2 />')
 
       diff = described_class.new << op1 << op2
 
-      expect(diff.to_xml).to eq("<op1 />\n<op2 />")
+      expect(diff.to_xml).to eq("<diff><op1 />\n<op2 /></diff>")
     end
 
-    it 'is an empty string if there are no operations' do
+    it 'is an empty diff tag if there are no operations' do
       diff = described_class.new
-      expect(diff.to_xml).to eq('')
+      expect(diff.to_xml).to eq('<diff />')
     end
   end
 end

--- a/spec/xml_patch_spec.rb
+++ b/spec/xml_patch_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe XmlPatch do
 
   describe 'apply...to' do
     it 'applies the patch to the xml' do
-      patch = '<remove sel="//foo" />'
+      patch = '<diff><remove sel="//foo" /></diff>'
       doc = '<bar><baz><foo /></baz><foo /></bar><foo />'
       expect(described_class.apply(patch).to(doc)).to eq('<bar><baz /></bar>')
     end


### PR DESCRIPTION
Originally the code didn't expect patch xml to have any kind of root
node. However, after re-reading the rfc I now realise that xml patches
should always have a <diff> root node (and in any case xml is invalid
without a root).

I've refactored to expect patches to have <diff> at the root.