### PR TITLE
Don't parse nested <remove> tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - Expect patch xml to have a <diff> root node
+- Don't parse nested <remove> tags
 
 ## [0.1.0] - 2017-11-01
 ### Added

--- a/lib/xml_patch/diff_builder.rb
+++ b/lib/xml_patch/diff_builder.rb
@@ -14,7 +14,7 @@ module XmlPatch
     end
 
     def parse(patch)
-      patch.parse do |name, attrs|
+      patch.get_at('/diff/*') do |name, attrs|
         case name
         when 'remove' then remove(attrs['sel'])
         end

--- a/spec/xml_patch/diff_builder_spec.rb
+++ b/spec/xml_patch/diff_builder_spec.rb
@@ -24,11 +24,21 @@ RSpec.describe XmlPatch::DiffBuilder do
   end
 
   describe 'parse' do
-    it 'does nothing when parsing the document yields nothing' do
+    it 'only gets the nodes at /diff/* from the document' do
+      patch = instance_double(XmlPatch::XmlDocument)
+      allow(patch).to receive(:get_at)
+
+      builder = described_class.new
+      builder.parse(patch)
+
+      expect(patch).to have_received(:get_at).with('/diff/*')
+    end
+
+    it 'does nothing when no xml tags are yielded by the document' do
       diff = XmlPatch::DiffDocument.new
 
       patch = instance_double(XmlPatch::XmlDocument)
-      allow(patch).to receive(:parse)
+      allow(patch).to receive(:get_at)
 
       builder = described_class.new
       builder.parse(patch)
@@ -40,7 +50,7 @@ RSpec.describe XmlPatch::DiffBuilder do
       diff = XmlPatch::DiffDocument.new
 
       patch = instance_double(XmlPatch::XmlDocument)
-      allow(patch).to receive(:parse).and_yield('foo', {})
+      allow(patch).to receive(:get_at).and_yield('foo', {})
 
       builder = described_class.new
       builder.parse(patch)
@@ -50,7 +60,7 @@ RSpec.describe XmlPatch::DiffBuilder do
 
     it 'calls remove for each remove tag yielded when parsing the document' do
       patch = instance_double(XmlPatch::XmlDocument)
-      allow(patch).to receive(:parse)
+      allow(patch).to receive(:get_at)
         .and_yield('remove', 'sel' => '/foo/bar')
         .and_yield('remove', 'sel' => '/baz/qux')
 


### PR DESCRIPTION
There's a bug in the code at present where we will parse and apply
<remove> tags anywhere in the patch document, even deeply nested
ones. Instead we should only be parsing operation tags at /diff/*.

To make this work I've changed from using a SAX parser to a DOM
parser, as I couldn't see a way to either limit the depth of the oga
SAX parser or check a node's position in the document tree. Instead we
only get nodes at the specific xpath /diff/*